### PR TITLE
[Bucket A] Add FOSSA SCA scan and Guardian manifest workflow

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,25 @@
+version: 3
+
+project:
+  locator: SolaceProducts_terraform-solacebrokerappliance-jndi
+  id: SolaceProducts_terraform-solacebrokerappliance-jndi
+  name: terraform-solacebrokerappliance-jndi
+  teams: []
+  labels:
+    - terraform
+
+vendoredDependencies:
+  forceRescans: false
+  scanMethod: CLILicenseScan
+  licenseScanPathFilters:
+    exclude:
+      - "./.git"
+      - "./.github"
+
+paths:
+  exclude:
+    - ./.git
+    - ./.github
+
+telemetry:
+  scope: full

--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -1,0 +1,8 @@
+{
+  "sca_scanning": {
+    "fossa": {
+      "policy": { "mode": "REPORT" },
+      "vulnerability": { "mode": "REPORT" }
+    }
+  }
+}

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -1,0 +1,51 @@
+name: SCA Scan on merge to main
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+  pull-requests: write
+  actions: read
+  checks: write
+  statuses: write
+
+jobs:
+  sca_scan:
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+
+  update_manifest:
+    needs: sca_scan
+    if: always() && needs.sca_scan.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::868978040651:role/github-solace-cloud-manifest-rw
+          aws-region: us-east-1
+
+      - name: Update solace-cloud-manifest
+        uses: SolaceDev/solace-public-workflows/.github/actions/cicd-helper@main
+        with:
+          rc_step: add_item_from_json_to_dynamodb_table
+          ddb_table_name: solace-cloud-manifest
+          ddb_partition_key: squad
+          ddb_sort_key: repository
+          ddb_item_to_be_added: |
+            {
+              "squad": "ebp",
+              "repository": "${{ github.event.repository.name }}",
+              "dev": {
+                "sha": "${{ github.sha }}",
+                "version": "${{ github.ref_name }}"
+              }
+            }

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -42,7 +42,7 @@ jobs:
           ddb_sort_key: repository
           ddb_item_to_be_added: |
             {
-              "squad": "ebp",
+              "squad": "ebp-dax",
               "repository": "${{ github.event.repository.name }}",
               "dev": {
                 "sha": "${{ github.sha }}",

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -7,10 +7,10 @@ permissions:
   contents: read
   id-token: write
   packages: read
-  pull-requests: write
   actions: read
-  checks: write
   statuses: write
+  checks: write
+  pull-requests: write
 
 jobs:
   sca_scan:
@@ -20,7 +20,7 @@ jobs:
 
   update_manifest:
     needs: sca_scan
-    if: always() && needs.sca_scan.result == 'success'
+    if: needs.sca_scan.result == 'success' && github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -28,7 +28,7 @@ jobs:
       packages: read
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: arn:aws:iam::868978040651:role/github-solace-cloud-manifest-rw
           aws-region: us-east-1


### PR DESCRIPTION
## Summary

- Adds `.fossa.yml` to configure the project in FOSSA under `SolaceProducts_<repo>` with label `terraform`
- Adds `.github/workflows/sca-scan-and-guard.yml` to run FOSSA SCA scanning on every merge to `main` and write the result to the `solace-cloud-manifest` DynamoDB table

## Test plan

- [ ] Verify workflow triggers on merge to `main` (REPORT mode — non-blocking)
- [ ] Confirm `SCA Scan on merge to main` workflow runs green after merge
- [ ] Confirm `update_manifest` job writes a row to `solace-cloud-manifest` DynamoDB with the correct `squad`/`repository` keys
- [ ] Confirm FOSSA dashboard shows a new revision for the merge commit

Part of DATAGO-142436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)